### PR TITLE
Linking library was encoding "," and "|".

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,9 +8,7 @@ const isValidCoordinates = coords =>
 const getParams = (params = []) => {
   return params
     .map(({ key, value }) => {
-      const encodedKey = encodeURIComponent(key)
-      const encodedValue = encodeURIComponent(value)
-      return `${encodedKey}=${encodedValue}`
+      return `${key}=${value}`
     })
     .join('&')
 }


### PR DESCRIPTION
Removed encodeURICOmponent which was messing up the final url.


Test Case:
```
handleGetDirections = () => {
    const data = {
       source: {
        latitude:Number(24.9158528),
        longitude:Number(67.1313890)
      },
      destination: {
        latitude: Number(24.9158528),
        longitude: Number(67.1313892)
      },
      params: [
        {
          key: "travelmode",
          value: "driving"        // may be "walking", "bicycling" or "transit" as well
        },
        {
          key: "dir_action",
          value: "navigate"       // this instantly initializes navigation using the given travel mode
        }
      ],
      waypoints: [
      
        {
          latitude: Number(-33.8600026),
          longitude: Number(18.697453)
        },
           {
          latitude: Number(-33.8600036),
          longitude: Number(18.697493)
        }
      ]
    }
  
    getDirections(data)
  }
```